### PR TITLE
2023/1月追加となる内容のチェック

### DIFF
--- a/contents/playbook-example.md
+++ b/contents/playbook-example.md
@@ -13,7 +13,7 @@ AnsibleやSmartCS用モジュールのバージョンなど、ご利用の環境
 
 ## 目次
 - [1. 特定のrecvcharを受信した際に特定のsendcharを送信する場合](./playbook-example.md#1-特定のrecvcharを受信した際に特定のsendcharを送信する場合)
-- [2. sendcharで指定した文字列の実行結果をファイルとして保存する際に、余分な改行を削除する場合](./playbook-example.md#2-sendcharで指定した文字列の実行結果をファイルとして保存する際に余分な改行を削除する場合)
+- [2. sendcharで実行したコマンドの実行結果から余分な改行を削除する場合](./playbook-example.md#2-sendcharで指定したコマンドの実行結果から余分な改行を削除する場合)
 
 <br>
 <br>
@@ -25,7 +25,7 @@ AnsibleやSmartCS用モジュールのバージョンなど、ご利用の環境
 <br>
 <br>
 
-## 2. [sendcharで指定した文字列の実行結果をファイルとして保存する際に、余分な改行を削除する場合](./playbook-example/convert_nl.md)
+## 2. [sendcharで指定したコマンドの実行結果から余分な改行を削除する場合](./playbook-example/convert_nl.md)
 
 * Cisco IOSと連携してコマンド実行結果をファイルに格納し、余分な空白行を削除するPlaybookの例となります。
 

--- a/contents/playbook-example/convert_nl.md
+++ b/contents/playbook-example/convert_nl.md
@@ -1,4 +1,4 @@
-# sendcharで指定した文字列の実行結果をファイルとして保存する際に、余分な改行を削除する場合
+# sendcharで指定したコマンドの実行結果から余分な改行を削除する場合
 
 [↑ ユースケース/サンプルPlaybook に戻る](../playbook-example.md)
 
@@ -19,7 +19,7 @@
   - name: execute show version on IOS
     seiko.smartcs.smartcs_tty_command:
       tty: '1'
-      cmd_timeout: '60'
+      cmd_timeout: 60
       recvchar: 
       - 'Switch>'
       - 'Switch#'

--- a/contents/smartcsmoduletips.md
+++ b/contents/smartcsmoduletips.md
@@ -40,9 +40,9 @@ Playbook の実行結果をエラーとしたい場合は、`failed` を指定�
 <br>
 <br>
 
-## 2. sendchar で指定した文字列の実行結果がstdout_lines_customのresponseに正しく格納されず、途中で切れてしまいます。
+## 2. sendchar で指定した文字列の実行結果が stdout_lines などに正しく格納されない。
 #### 想定原因
-実行結果の出力内容が多い（長い）場合、出力にかかる時間に対して`smartcs_tty_command` の`cmd_timeout` オプションで指定している時間が短すぎる、あるいは`smartcs_tty_command` の`__WAIT__` オプションおよび`__NOWAIT__` オプションで指定している時間が短すぎるために、出力内容が`response` に入りきらず、次の`execute_command` や`response` に格納されてしまっている可能性があります。
+実行結果の出力内容が多い（長い）場合、出力にかかる時間に対して`smartcs_tty_command` の`cmd_timeout` オプションで指定している時間が短すぎる、あるいは`smartcs_tty_command` の`__WAIT__` オプションおよび`__NOWAIT__` オプションで指定している時間が短すぎるために、出力内容が `stdout`、`stdout_lines`、`stdout_lines_custom`の`response` データに入りきらず、次の`execute_command` や`response` に格納されてしまっている可能性があります。
 
 #### 対処方法
 `smartcs_tty_command` の`cmd_timeout` オプションや、`__WAIT__` オプション、`__NOWAIT__` オプションで指定している時間を、戻り値を出力しきれる秒数に設定してください。<br>


### PR DESCRIPTION
- トラブルシューティング (SmartCS x Ansible)の 2の内容修正
  - タイトルを短く変更
  - 格納先として、stdout_lines_custom 以外でも同様の事が起こり得るので レスポンスデータの格納先を複数記載
- ユースケース/サンプルPlaybook 目次の 項番2のタイトルを修正
- サンプルPlaybook2ページの修正
  - タイトルを目次と合わせて短く修正
  - Playbookの cmd_timeout について文字列指定でなくint型に修正（'60' → 60 ）
